### PR TITLE
When data is found in one cache, break out the loop

### DIFF
--- a/src/Digipolis.Caching/Digipolis.Caching.csproj
+++ b/src/Digipolis.Caching/Digipolis.Caching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Description>Deze package biedt caching functionaliteit aan in een .NET Core project</Description>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/src/Digipolis.Caching/Services/CacheService.cs
+++ b/src/Digipolis.Caching/Services/CacheService.cs
@@ -113,6 +113,7 @@ namespace Digipolis.Caching.Services
                         {
                             itemFoundInCacheTierNumber = i;
                             result = cacheResult;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
It would always look in both caches, even when data was already found InMemory.
By doing so, the code always thinks data was found in the DistributedCache and would update the InMemory.